### PR TITLE
Possibility to use in an activity without statusbar

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.3"
     defaultConfig {
         applicationId "com.irozon.sneakersample"
         minSdkVersion 19
@@ -27,8 +26,8 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:27.0.2'
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
+    compile 'com.android.support:appcompat-v7:27.1.1'
+    compile 'com.android.support.constraint:constraint-layout:1.1.1'
     testCompile 'junit:junit:4.12'
 
     compile project(':sneaker')

--- a/app/src/main/java/com/irozon/sneakersample/MainActivity.java
+++ b/app/src/main/java/com/irozon/sneakersample/MainActivity.java
@@ -4,6 +4,8 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
+import android.view.Window;
+import android.view.WindowManager;
 import android.widget.Button;
 
 import com.irozon.sneaker.Sneaker;
@@ -13,6 +15,9 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     Button btShowError;
     Button btShowSuccess;
     Button btShowWarning;
+    Button btToggleStatusBar;
+
+    boolean isStatusBarVisible = true;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -22,10 +27,12 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         btShowError = (Button) findViewById(R.id.btShowError);
         btShowSuccess = (Button) findViewById(R.id.btShowSuccess);
         btShowWarning = (Button) findViewById(R.id.btShowWarning);
+        btToggleStatusBar = (Button) findViewById(R.id.btToggleStatusBar);
 
         btShowError.setOnClickListener(this);
         btShowSuccess.setOnClickListener(this);
         btShowWarning.setOnClickListener(this);
+        btToggleStatusBar.setOnClickListener(this);
     }
 
     @Override
@@ -33,23 +40,36 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         switch (v.getId()) {
             case R.id.btShowError:
                 Sneaker.with(this)
-                        .setTitle("Error!!")
-                        .setMessage("This is the error message")
-                        .setTypeface(Typeface.createFromAsset(this.getAssets(), "font/" + "Slabo27px-Regular.ttf"))
-                        .sneakError();
+                       .setTitle("Error!!")
+                       .setMessage("This is the error message")
+                       .setTypeface(Typeface.createFromAsset(this.getAssets(), "font/" + "Slabo27px-Regular.ttf"))
+                       .sneakError();
                 break;
             case R.id.btShowSuccess:
                 Sneaker.with(this)
-                        .setTitle("Success!!")
-                        .setMessage("This is the success message")
-                        .setCornerRadius(5, 7)
-                        .sneakSuccess();
+                       .setTitle("Success!!")
+                       .setMessage("This is the success message")
+                       .setCornerRadius(5, 7)
+                       .sneakSuccess();
                 break;
             case R.id.btShowWarning:
                 Sneaker.with(this)
-                        .setTitle("Warning!!")
-                        .setMessage("This is the warning message")
-                        .sneakWarning();
+                       .setTitle("Warning!!")
+                       .setMessage("This is the warning message")
+                       .sneakWarning();
+                break;
+            case R.id.btToggleStatusBar:
+                Window w = getWindow();
+                if (isStatusBarVisible) {
+                    w.addFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS);
+                    w.addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
+                    isStatusBarVisible = false;
+                } else {
+                    w.clearFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS);
+                    w.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
+                    isStatusBarVisible = true;
+                }
+
                 break;
         }
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,30 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:layout_marginEnd="16dp"
-    android:layout_marginStart="16dp"
-    android:gravity="center"
-    android:orientation="vertical"
-    tools:context="com.irozon.sneakersample.MainActivity">
+              xmlns:tools="http://schemas.android.com/tools"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:layout_marginEnd="16dp"
+              android:layout_marginStart="16dp"
+              android:gravity="center"
+              android:orientation="vertical"
+              tools:context="com.irozon.sneakersample.MainActivity">
 
     <Button
         android:id="@+id/btShowError"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Show Error" />
+        android:text="Show Error"/>
 
     <Button
         android:id="@+id/btShowSuccess"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Show Success" />
+        android:text="Show Success"/>
 
     <Button
         android:id="@+id/btShowWarning"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Show Warning" />
+        android:text="Show Warning"/>
+
+    <Button
+        android:id="@+id/btToggleStatusBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Toggle StatusBar"/>
 
 </LinearLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.3'
 
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Feb 27 20:42:23 EET 2018
+#Sun Jun 17 15:41:42 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/sneaker/build.gradle
+++ b/sneaker/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.3"
 
     defaultConfig {
         minSdkVersion 16
@@ -22,10 +21,10 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:27.0.2'
-    testCompile 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    testImplementation 'junit:junit:4.12'
 }

--- a/sneaker/src/main/java/com/irozon/sneaker/Utils.java
+++ b/sneaker/src/main/java/com/irozon/sneaker/Utils.java
@@ -20,13 +20,8 @@ class Utils {
      */
     static int getStatusBarHeight(Activity activity) {
         Rect rectangle = new Rect();
-        Window window = activity.getWindow();
-        window.getDecorView().getWindowVisibleDisplayFrame(rectangle);
-        int statusBarHeight = rectangle.top;
-        int contentViewTop = window.findViewById(Window.ID_ANDROID_CONTENT).getTop();
-        int titleBarHeight = contentViewTop - statusBarHeight;
-
-        return statusBarHeight;
+        activity.getWindow().getDecorView().getWindowVisibleDisplayFrame(rectangle);
+        return Math.max(rectangle.top, Utils.convertToDp(activity, 26));
     }
 
     static int convertToDp(Context context, float sizeInDp) {
@@ -38,7 +33,9 @@ class Utils {
         int radiusInDP = convertToDp(context, cornerRadius);
         GradientDrawable shape = new GradientDrawable();
         shape.setShape(GradientDrawable.RECTANGLE);
-        shape.setCornerRadii(new float[] { radiusInDP, radiusInDP, radiusInDP, radiusInDP, radiusInDP, radiusInDP, radiusInDP, radiusInDP });
+        shape.setCornerRadii(
+                new float[]{radiusInDP, radiusInDP, radiusInDP, radiusInDP, radiusInDP, radiusInDP, radiusInDP,
+                            radiusInDP});
         shape.setColor(backgroundColor);
         v.setBackground(shape);
     }


### PR DESCRIPTION
I had an error using this lib in activities which don't have a statusbar (the view is never shown).
What I did is to change the function `com.irozon.sneaker.Utils$getStatusBarHeight(Activity activity)`.

```
static int getStatusBarHeight(Activity activity) {
        Rect rectangle = new Rect();
        activity.getWindow().getDecorView().getWindowVisibleDisplayFrame(rectangle);
        return Math.max(rectangle.top, Utils.convertToDp(activity, 26));
    }
```
It simply return the statusbar's height, and if it's below `26dp`, it returns `26dp`.

The other source code modified is just to test.

Please, deploy a new version of your lib with this fix, because I really would like to use it in my projects ❤️ 